### PR TITLE
Add liveview error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Capture exceptions and send them to the [Bugsnag](https://www.bugsnag.com/) API!
     - [`exception_filter`](#exception_filter)
     - [`json_library`](#json_library)
     - [`http_client`](#http_client)
+    - [`socket_metadata_extractor`](#socket_metadata_extractor)
   - [Usage](#usage)
     - [Manual Reporting](#manual-reporting)
     - [Reporting Options](#reporting-options)
+  - [License](#license)
 
 <!-- /MarkdownTOC -->
 
@@ -109,7 +111,8 @@ config :bugsnag,
   notify_release_stages: ["staging", "production"],
   release_stage: {:system, "MY_APP_ENV", "production"},
   sanitizer: {MyModule, :my_function},
-  use_logger: true
+  use_logger: true,
+  socket_metadata_extractor: {MyModule, :my_function}
 ```
 
 See below for explanations of each option, including some options not used here.
@@ -267,6 +270,35 @@ The JSON encoding library.
 **Default** `Bugsnag.HTTPClient.Adapters.HTTPoison`
 
 An adapter implementing the `Bugsnag.HTTPClient` behaviour.
+
+### `socket_metadata_extractor`
+
+**Default** `nil`
+
+If nothing is provided, we extract the user info `{id: id, name: name, email: email}` from
+an expected `current_user` within the socket.
+
+Example
+
+```elixir
+defmodule MyModule do
+  def my_func(socket) do
+    %{user: socket.assigns.current_user}
+  end
+end
+
+config :bugsnag, sanitizer: {MyModule, :my_func}
+```
+
+```elixir
+%Socket{
+  assigns: %{current_user: %{name: "Name"}}
+}
+```
+
+Will add a metadata of `%{user: %{name: "Name"}}`, which will be visible in the bugsnag dashboard.
+
+
 
 ## Usage
 

--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -17,20 +17,56 @@ defmodule Bugsnag.Logger do
 
   def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
       when is_list(message) do
+    case message[:initial_call] do
+      # do nothing in case of live_view
+      {Phoenix.LiveView.Channel, :init, _} ->
+        nil
+
+      _ ->
+        handle_error(message)
+    end
+
+    {:ok, state}
+  end
+
+  # Handle event for LiveView
+  def handle_event(
+        {:error, _gl,
+         {pid, _msg,
+          [
+            pid,
+            last_event,
+            %{socket: %{assigns: %{}} = socket},
+            {exception, stacktrace}
+          ]}},
+        state
+      )
+      when is_list(stacktrace) do
+    # Handle liveview
     try do
-      error_info = message[:error_info]
+      # We only want to send the last event for Phoenix.Socket.Message
+      last_event =
+        case last_event do
+          %{payload: payload} -> payload
+          _ -> nil
+        end
 
-      case error_info do
-        {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
-          Bugsnag.report(exception, stacktrace: stacktrace)
+      base_metadata = %{last_event: last_event}
+      options = %{stacktrace: stacktrace}
 
-        {_kind, exception, stacktrace} ->
-          Bugsnag.report(exception, stacktrace: stacktrace)
-      end
+      options =
+        case extract_socket_metadata(socket) do
+          %{metadata: metadata} ->
+            Map.put(options, :metadata, Map.merge(base_metadata, metadata))
+
+          other when is_map(other) ->
+            options |> Map.put(:metadata, base_metadata) |> Map.merge(other)
+        end
+        |> Keyword.new()
+
+      Bugsnag.report(exception, options)
     rescue
-      ex ->
-        error_message = Exception.format(:error, ex)
-        Logger.warn("Unable to notify Bugsnag. #{error_message}")
+      ex -> report_failure(ex)
     end
 
     {:ok, state}
@@ -39,4 +75,49 @@ defmodule Bugsnag.Logger do
   def handle_event({_level, _gl, _event}, state) do
     {:ok, state}
   end
+
+  defp handle_error(message) do
+    try do
+      error_info = message[:error_info]
+
+      case error_info do
+        # Else do the following
+        {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
+          Bugsnag.report(exception, stacktrace: stacktrace)
+
+        {_kind, exception, stacktrace} ->
+          Bugsnag.report(exception, stacktrace: stacktrace)
+      end
+    rescue
+      ex -> report_failure(ex)
+    end
+  end
+
+  defp report_failure(ex) do
+    error_message = Exception.format(:error, ex)
+    Logger.warn("Unable to notify Bugsnag. #{error_message}")
+  end
+
+  defp extract_socket_metadata(socket) do
+    extractor = Application.get_env(:bugsnag, :socket_metadata_extractor)
+
+    if extractor do
+      {module, function} = extractor
+      %{metadata: apply(module, function, [socket])}
+    else
+      extract_user_info(socket)
+    end
+  end
+
+  defp extract_user_info(socket) do
+    %{
+      user: socket.assigns[:current_user] |> user_info()
+    }
+  end
+
+  defp user_info(%{id: id, name: name, email: email}) do
+    %{id: id, email: email, name: name}
+  end
+
+  defp user_info(_), do: nil
 end

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -1,6 +1,10 @@
 defmodule BugsnagTest do
   use ExUnit.Case
 
+  alias Bugsnag.HTTPMock
+  alias Bugsnag.HTTPClient.Request
+  alias Bugsnag.HTTPClient.Response
+
   import ExUnit.CaptureLog
 
   defmodule FilterAll do
@@ -13,6 +17,14 @@ defmodule BugsnagTest do
 
   defmodule FilterCrash do
     def should_notify(_e, _s), do: raise("boom")
+  end
+
+  setup_all do
+    Application.put_env(:bugsnag, :http_client, HTTPMock)
+
+    on_exit(fn ->
+      Application.delete_env(:bugsnag, :http_client)
+    end)
   end
 
   setup do
@@ -38,6 +50,7 @@ defmodule BugsnagTest do
     Application.put_env(:bugsnag, :release_stage, "production")
     on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
 
+    Mox.expect(HTTPMock, :post, fn %Request{} -> {:ok, Response.new(200, [], "body")} end)
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
 
@@ -136,6 +149,7 @@ defmodule BugsnagTest do
     on_exit(fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end)
     on_exit(fn -> Application.put_env(:bugsnag, :exception_filter, nil) end)
 
+    Mox.expect(HTTPMock, :post, fn %Request{} -> {:ok, Response.new(200, [], "body")} end)
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
 
@@ -150,6 +164,7 @@ defmodule BugsnagTest do
     on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
     on_exit(fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end)
 
+    Mox.expect(HTTPMock, :post, fn %Request{} -> {:ok, Response.new(200, [], "body")} end)
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
 
@@ -164,6 +179,7 @@ defmodule BugsnagTest do
     on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
     on_exit(fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end)
 
+    Mox.expect(HTTPMock, :post, fn %Request{} -> {:ok, Response.new(200, [], "body")} end)
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
 end


### PR DESCRIPTION
* When the liveview crashes in mount, it'll be handled by the normal phoenix conn flow and does not need to be handled specifically.
Ref: https://hexdocs.pm/phoenix_live_view/error-handling.html#exceptions-on-mount

* When it crashes in events, handle it by the new pattern match in handle_event in logger.